### PR TITLE
Use HTTP1.1 downloading OVA

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -34,7 +34,9 @@ extract_ova_parts() {
 
 download_ova_parts() {
   clean_ova_parts
-  curl -Z \
+  curl \
+    --http1.1 \
+    --parallel \
     --parallel-max 32 \
     $OVA_URL \
     -o 'sol-11_4-part#1.zip'


### PR DESCRIPTION
It seems that downloading the OVA with `--http1.1` could prevent [this error](https://github.com/mondeja/pacapt/runs/3743234051?check_suite_focus=true#step:5:967):

```
--  --  2725M     0    76    23     0 --:--:--  0:11:16 --:--:--     0      curl: (92) HTTP/2 stream 37 was not closed cleanly before end of the underlying stream
curl: (92) HTTP/2 stream 43 was not closed cleanly before end of the underlying stream
curl: (92) HTTP/2 stream 47 was not closed cleanly before end of the underlying stream
```